### PR TITLE
Lower hook priority

### DIFF
--- a/TemplateEngineFactory.module.php
+++ b/TemplateEngineFactory.module.php
@@ -78,7 +78,7 @@ class TemplateEngineFactory extends WireData implements Module, ConfigurableModu
             return;
         }
         $this->wire($this->get('api_var'), $engine);
-        $this->addHookAfter('Page::render', $this, 'hookRender', array('priority'=>'99'));
+        $this->addHookAfter('Page::render', $this, 'hookRender', array('priority'=>'100.01'));
         // If the engine supports caching, attach hooks to clear the cache when saving/deleting pages
         if (in_array('TemplateEngineCache', class_implements($engine))) {
             $this->wire('pages')->addHookAfter('save', $this, 'hookClearCache');

--- a/TemplateEngineFactory.module.php
+++ b/TemplateEngineFactory.module.php
@@ -78,7 +78,7 @@ class TemplateEngineFactory extends WireData implements Module, ConfigurableModu
             return;
         }
         $this->wire($this->get('api_var'), $engine);
-        $this->addHookAfter('Page::render', $this, 'hookRender');
+        $this->addHookAfter('Page::render', $this, 'hookRender', array('priority'=>'99'));
         // If the engine supports caching, attach hooks to clear the cache when saving/deleting pages
         if (in_array('TemplateEngineCache', class_implements($engine))) {
             $this->wire('pages')->addHookAfter('save', $this, 'hookClearCache');


### PR DESCRIPTION
Hi Wanze,

I'm not sure if this will fix the problem, but I've noticed some other modules that add markup using a Page::render hook have to raise their hook's priority above TemplateEngineFactory's priority to make sure their hook has a higher priority.

I believe in both cases the modules were outputting html right before the closing body tag using the Page::render hook.

I ran into this problem with Tracy Debugger and https://github.com/madebymats/FieldtypeLeafletMapMarker.

Tracy Debugger is fixed now by raising it's hook priority really high.  I have a pull request https://github.com/madebymats/FieldtypeLeafletMapMarker/pull/9 to fix it for FieldtypeLeafletMapMarker, but should all other modules have to do this?  Can TemplateEngineFactory lower it's priority so other modules won't have to raise their priority?

Here's what it looks like on my site:
![image](https://cloud.githubusercontent.com/assets/40570/23345071/80acd3e0-fc4d-11e6-8c58-e611bd5fe2e0.png)

Notice how the MarkupAddInlineScript module (100.1) runs before TemplateEngineTwig (100.3)?  In this case the Leaflet initialization javascript markup doesn't get added before the closing body tag.

The only thing I'm not sure of is if it is ok to go under 100 which is the default priority?

Maybe this module should set it to 100.1?  I'm not sure.  Maybe you know more about this?